### PR TITLE
Update popup.js

### DIFF
--- a/popup.js
+++ b/popup.js
@@ -21,11 +21,14 @@ checkPageButton.addEventListener('click', function() {
 
     count.innerHTML = list.length
 
+    var trueUpdateCount=0;
     list.forEach((x) => {
       let newItem = document.createElement('li')
       newItem.innerHTML = x
-
-      displayList.appendChild(newItem)
+      if(displayList.innerHTML.indexOf("<li>"+x+"</li>")==-1){
+        displayList.appendChild(newItem);
+        trueUpdateCount++;
+      }
     })
   });
 }, false);
@@ -39,4 +42,3 @@ function getData(list) {
 
   chrome.storage.local.set({ list: list });
 }
-


### PR DESCRIPTION
Hitting "Generate list now!" multiple times causes duplicate entries. With this only new names will be added at the bottom. Should also generate a more accurate participant count number.